### PR TITLE
WIP: Fixed Drupal Attributes are not merged / empty.

### DIFF
--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -66,7 +66,6 @@ foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
   }
   if (!isset($passed_variables[$name])) {
     $variables[$name] = new \Drupal\Core\Template\Attribute($defaults[$name]);
-    continue;
   }
   else {
     $variables[$name] = $passed_variables[$name];
@@ -78,9 +77,9 @@ foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
         $variables[$name][$default_key] = $default_value;
       }
     }
-    if ($name === 'attributes' && isset($defaults['class'])) {
-      $variables[$name]->addClass($defaults['class']);
-    }
+  }
+  if ($name === 'attributes' && isset($defaults['class'])) {
+    $variables[$name]->addClass($defaults['class']);
   }
 }
 EOD

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -65,23 +65,24 @@ class Render extends Twig_Node_Include {
     $compiler->raw(");\n");
 
     $compiler->write(<<<'EOD'
-foreach ($variables as $context_key => $passed_variable) {
-  if (isset($defaults[$context_key]) && $passed_variable instanceof \Drupal\Core\Template\Attribute) {
-    foreach ($defaults[$context_key] as $name => $value) {
-      if (!isset($passed_variable[$name])) {
-        $passed_variable[$name] = $value;
-      }
-    }
-    if ($context_key === 'attributes' && isset($defaults['class'])) {
-      $passed_variable->addClass($defaults['class']);
-    }
-  }
-}
+//foreach ($defaults as $default_key => $default_value) {
+//  $passed_variable = $variables[$default_key] ?? NULL;
+//  if ($passed_variable instanceof \Drupal\Core\Template\Attribute) {
+//    foreach ($defaults[$default_key] as $name => $value) {
+//      if (!isset($passed_variable[$name])) {
+//        $passed_variable[$name] = $value;
+//      }
+//    }
+//    if ($default_key === 'attributes' && isset($defaults['class'])) {
+//      $passed_variable->addClass($defaults['class']);
+//    }
+//  }
+//}
 foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
-  if (!isset($variables[$name])) {
-    $variables[$name] = [];
-  }
-  if (!$variables[$name] instanceof \Drupal\Core\Template\Attribute) {
+  if (isset($defaults[$name])) {
+    $defaults[$name] = !isset($defaults[$name]) ? [] : $defaults[$name];
+    $variables[$name] = !isset($variables[$name]) ? [] : $variables[$name]->toArray();
+    $variables[$name] = array_merge_recursive($defaults[$name], $variables[$name]);
     $variables[$name] = new \Drupal\Core\Template\Attribute($variables[$name]);
   }
 }

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -8,6 +8,7 @@
 namespace Drupal\twig_fractal\Node;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Template\Attribute;
 use Symfony\Component\Yaml\Yaml;
 use Twig_Compiler;
 use Twig_Node_Expression;
@@ -65,10 +66,24 @@ class Render extends Twig_Node_Include {
    */
   protected function addTemplateArguments(Twig_Compiler $compiler) {
     $defaults = $this->getComponentDefaults($this->component);
-
-    $compiler->raw('array_merge($context,')->repr($defaults);
+    $compiler->raw('array_replace_recursive(')->repr($defaults);
     if ($this->hasNode('variables')) {
       $compiler->raw(',')->subcompile($this->getNode('variables'));
+//      foreach ($context as $context_key => $context_value) {
+//        if ($context_value instanceof \Drupal\Core\Template\Attribute) {
+//          foreach ($defaults['attr'] as $name => $value) {
+//            if (!isset($context_value[$name])) {
+//              $context_value[$name] = $value;
+//            }
+//            elseif ($name === 'class') {
+//              $context_value->addClass($value);
+//            }
+//          }
+//        }
+//      }
+      $compiler->raw(', [\'attr\' => new \Drupal\Core\Template\Attribute(array_merge(')->repr($defaults['attr'])->raw(', $context[\'title_attributes\']->toArray()')->raw('))]');
+      #$compiler->raw('array_merge($context['attributes']')->repr([]);
+      #$compiler->raw(')');
     }
     $compiler->raw(')');
   }
@@ -88,12 +103,24 @@ class Render extends Twig_Node_Include {
     $component = $this->getComponentParts($component);
 
     $defaults = [];
-    if ($component['variant'] && isset($component_definition['variants'])) {
+    if (0 &&$component['variant'] && isset($component_definition['variants'])) {
       $defaults += $this->getVariantDefaults($component['variant'], $component_definition['variants']);
     }
     else {
       $defaults += (array) $component_definition['context'];
+      #$defaults['attr'] = array_merge($defaults['attr'], $component_definition['context']['attr']);
+      $defaults['attr']['title'] = 'Hello world';
     }
+    $attributes = [];
+    if (isset($defaults['class'])) {
+      $attributes['class'] = $defaults['class'];
+    }
+    if (isset($defaults['attr'])) {
+      $attributes += $defaults['attr'];
+    }
+//    if (!empty($attributes)) {
+//      $defaults['attributes'] = new Attribute($attributes);
+//    }
     return $defaults;
   }
 

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -8,7 +8,6 @@
 namespace Drupal\twig_fractal\Node;
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Template\Attribute;
 use Symfony\Component\Yaml\Yaml;
 use Twig_Compiler;
 use Twig_Node_Expression;
@@ -84,16 +83,7 @@ foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
 }
 EOD
     );
-
-    $compiler
-      ->write('$this->loadTemplate(')
-      ->subcompile($this->getNode('expr'))
-      ->raw(', ')
-      ->repr($this->getTemplateName())
-      ->raw(', ')
-      ->repr($this->getTemplateLine())
-      ->raw(')')
-    ;
+    parent::addGetTemplate($compiler);
   }
 
   /**
@@ -111,14 +101,6 @@ EOD
    */
   protected function addTemplateArguments(Twig_Compiler $compiler) {
     $compiler->raw('$variables');
-    return;
-    $defaults = $this->getComponentDefaults($this->component);
-    $compiler->raw('array_merge(')->repr($defaults);
-    if ($this->hasNode('variables')) {
-      $compiler->raw(',')->subcompile($this->getNode('variables'));
-      $compiler->raw(', [\'attributes\' => new \Drupal\Core\Template\Attribute(')->repr($defaults['attributes'])->raw(')]');
-    }
-    $compiler->raw(')');
   }
 
   /**
@@ -136,22 +118,12 @@ EOD
     $component = $this->getComponentParts($component);
 
     $defaults = [];
-    if (0 &&$component['variant'] && isset($component_definition['variants'])) {
+    if ($component['variant'] && isset($component_definition['variants'])) {
       $defaults += $this->getVariantDefaults($component['variant'], $component_definition['variants']);
     }
     else {
       $defaults += (array) $component_definition['context'];
     }
-    $attributes = [];
-    if (isset($defaults['class'])) {
-      $attributes['class'] = $defaults['class'];
-    }
-    if (isset($defaults['attr'])) {
-      $attributes += $defaults['attr'];
-    }
-//    if (!empty($attributes)) {
-//      $defaults['attributes'] = new Attribute($attributes);
-//    }
     return $defaults;
   }
 

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -50,42 +50,6 @@ class Render extends Twig_Node_Include {
     parent::__construct($expr, $variables, $only, $ignoreMissing, $lineno);
   }
 
-  protected function addGetTemplate(Twig_Compiler $compiler) {
-    $defaults = $this->getComponentDefaults($this->component);
-    $compiler->raw('$defaults = ')->repr($defaults)->raw(';');
-
-    $compiler->raw('$passed_variables = ')->subcompile($this->getNode('variables'))->raw(';');
-    $compiler->raw('$variables = array_merge($defaults, $passed_variables);');
-    $compiler->raw('unset($variables[\'attributes\'], $variables[\'title_attributes\'], $variables[\'content_attributes\']);');
-
-    $compiler->write(<<<'EOD'
-foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
-  if (!isset($defaults[$name])) {
-    continue;
-  }
-  if (!isset($passed_variables[$name])) {
-    $variables[$name] = new \Drupal\Core\Template\Attribute($defaults[$name]);
-  }
-  else {
-    $variables[$name] = $passed_variables[$name];
-    if (!$variables[$name] instanceof \Drupal\Core\Template\Attribute) {
-      $variables[$name] = new \Drupal\Core\Template\Attribute($variables[$name]);
-    }
-    foreach ($defaults[$name] as $default_key => $default_value) {
-      if (!isset($variables[$name][$default_key])) {
-        $variables[$name][$default_key] = $default_value;
-      }
-    }
-  }
-  if ($name === 'attributes' && isset($defaults['class'])) {
-    $variables[$name]->addClass($defaults['class']);
-  }
-}
-EOD
-    );
-    parent::addGetTemplate($compiler);
-  }
-
   /**
    * Adds the template variables to the compiled Twig PHP template string.
    *
@@ -96,6 +60,47 @@ EOD
    * 2. the `context` properties of the requested variants (if any) in the
    *    component's definition file, which may be overridden by
    * 3. the variables passed to the `render` tag itself.
+   *
+   * @param \Twig_Compiler $compiler
+   */
+  protected function addGetTemplate(Twig_Compiler $compiler) {
+    $defaults = $this->getComponentDefaults($this->component);
+    $compiler->raw('$defaults = ')->repr($defaults)->raw(';');
+
+    $compiler->raw('$passed_variables = ')->subcompile($this->getNode('variables'))->raw(';');
+    $compiler->raw('$variables = array_merge($defaults, $passed_variables);');
+    $compiler->raw('unset($variables[\'attributes\'], $variables[\'title_attributes\'], $variables[\'content_attributes\']);');
+
+    $compiler->write(<<<'EOD'
+      foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
+        if (!isset($defaults[$name])) {
+          continue;
+        }
+        if (!isset($passed_variables[$name])) {
+          $variables[$name] = new \Drupal\Core\Template\Attribute($defaults[$name]);
+        }
+        else {
+          $variables[$name] = $passed_variables[$name];
+          if (!$variables[$name] instanceof \Drupal\Core\Template\Attribute) {
+            $variables[$name] = new \Drupal\Core\Template\Attribute($variables[$name]);
+          }
+          foreach ($defaults[$name] as $default_key => $default_value) {
+            if (!isset($variables[$name][$default_key])) {
+              $variables[$name][$default_key] = $default_value;
+            }
+          }
+        }
+        if ($name === 'attributes' && isset($defaults['class'])) {
+          $variables[$name]->addClass($defaults['class']);
+        }
+      }
+EOD
+    );
+    parent::addGetTemplate($compiler);
+  }
+
+  /**
+   * Passes the precompiled template variables to the Twig PHP template display method.
    *
    * @param \Twig_Compiler $compiler
    */

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -65,24 +65,23 @@ class Render extends Twig_Node_Include {
     $compiler->raw(");\n");
 
     $compiler->write(<<<'EOD'
-//foreach ($defaults as $default_key => $default_value) {
-//  $passed_variable = $variables[$default_key] ?? NULL;
-//  if ($passed_variable instanceof \Drupal\Core\Template\Attribute) {
-//    foreach ($defaults[$default_key] as $name => $value) {
-//      if (!isset($passed_variable[$name])) {
-//        $passed_variable[$name] = $value;
-//      }
-//    }
-//    if ($default_key === 'attributes' && isset($defaults['class'])) {
-//      $passed_variable->addClass($defaults['class']);
-//    }
-//  }
-//}
+foreach ($variables as $context_key => $passed_variable) {
+  if (isset($defaults[$context_key]) && $passed_variable instanceof \Drupal\Core\Template\Attribute) {
+    foreach ($defaults[$context_key] as $name => $value) {
+      if (!isset($passed_variable[$name])) {
+        $passed_variable[$name] = $value;
+      }
+    }
+    if ($context_key === 'attributes' && isset($defaults['class'])) {
+      $passed_variable->addClass($defaults['class']);
+    }
+  }
+}
 foreach (['attributes', 'title_attributes', 'content_attributes'] as $name) {
-  if (isset($defaults[$name])) {
-    $defaults[$name] = !isset($defaults[$name]) ? [] : $defaults[$name];
-    $variables[$name] = !isset($variables[$name]) ? [] : $variables[$name]->toArray();
-    $variables[$name] = array_merge_recursive($defaults[$name], $variables[$name]);
+  if (!isset($variables[$name])) {
+    $variables[$name] = [];
+  }
+  if (!$variables[$name] instanceof \Drupal\Core\Template\Attribute) {
     $variables[$name] = new \Drupal\Core\Template\Attribute($variables[$name]);
   }
 }


### PR DESCRIPTION
Problem
* Drupal Attributes are not merged correctly; the default values of the component definition file do not end up in the Fractal Twig template.

Example usage
```diff
diff --git a/docroot/themes/custom/nepo/styleguide-src/components/01-atoms/headline/headline.twig b/docroot/themes/custom/nepo/styleguide-src/components/01-atoms/headline/headline.twig
index cd0f132..1cab81b 100644
--- a/docroot/themes/custom/nepo/styleguide-src/components/01-atoms/headline/headline.twig
+++ b/docroot/themes/custom/nepo/styleguide-src/components/01-atoms/headline/headline.twig
@@ -1,4 +1,2 @@
-<{{ tag }} {{ attributes }}>{{ text }}</{{ tag }}>
+<{{ tag }} {{ attr }} class="">{{ text }}</{{ tag }}>
+{{ kint(attr) }}

diff --git a/docroot/themes/custom/nepo/templates/base/node.html.twig b/docroot/themes/custom/nepo/templates/base/node.html.twig
index e66691a..39e4cb8 100755
--- a/docroot/themes/custom/nepo/templates/base/node.html.twig
+++ b/docroot/themes/custom/nepo/templates/base/node.html.twig
@@ -85,7 +85,12 @@
   {% block content %}
     {{ title_prefix }}
     {% if not page %}
-      <h1{{ title_attributes.addClass(title_classes) }}><a href="{{ url }}" rel="bookmark">{{ label }}</a></h1>
+      {% render '@atoms/headline/headline.twig' with {
+        text: label,
+        attr: title_attributes
+      } %}
     {% endif %}
     {{ title_suffix }}
```