### PR TITLE
Added subtheme support to override components of base themes.

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -153,8 +153,8 @@ class Component {
    */
   protected function getDefinitionFilePath(string $pathname): string {
     $library = Drupal::service('twig.loader.twig_fractal');
-    $path = pathinfo($library->getCacheKey($pathname));
-    return $path['dirname'] . '/' . $path['filename'] . '.config.yml';
+    $pathinfo = pathinfo($pathname);
+    return $library->getCacheKey($pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.config.yml');
   }
 
   /**

--- a/src/Component.php
+++ b/src/Component.php
@@ -152,7 +152,7 @@ class Component {
    *   The relative path for the component definition file.
    */
   protected function getDefinitionFilePath(string $pathname): string {
-    $library = Drupal::service('twig.loader.componentlibrary');
+    $library = Drupal::service('twig.loader.twig_fractal');
     $path = pathinfo($library->getCacheKey($pathname));
     return $path['dirname'] . '/' . $path['filename'] . '.config.yml';
   }

--- a/src/TwigLoader.php
+++ b/src/TwigLoader.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\twig_fractal\Component.
+ */
+
+namespace Drupal\twig_fractal;
+
+use Drupal;
+use Drupal\components\Template\Loader\ComponentLibraryLoader;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
+
+/**
+ * Prepares paths to make fractal components overridable by a sub theme.
+ *
+ * To make components overridable by a sub theme, the existing namespace paths
+ * are getting prepended with adjusted sub theme paths.
+ *
+ * @see http://symfony.com/doc/current/templating/namespaced_paths.html#multiple-paths-per-namespace
+ */
+class TwigLoader extends ComponentLibraryLoader {
+
+  /**
+   * Prepends sub theme component paths to the existing base theme path namespaces.
+   *
+   * {@inheritdoc}
+   */
+  public function __construct($paths = [], ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler) {
+    parent::__construct($paths, $module_handler, $theme_handler);
+    $default_theme = $theme_handler->getTheme($theme_handler->getDefault());
+    if (!$default_theme->base_theme || !$base_theme = $theme_handler->getTheme($default_theme->base_theme)) {
+      return;
+    }
+    foreach ($base_theme->info['component-libraries'] as $namespace => $component) {
+      $paths = isset($component['paths']) ? $component['paths'] : [];
+      foreach ($paths as $path) {
+        $this->prependPath($default_theme->getPath() . '/' . $path, $namespace);
+      }
+    }
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prependPath($path, $namespace = self::MAIN_NAMESPACE) {
+    $this->cache = $this->errorCache = [];
+    $path = rtrim($path, '/\\');
+    if (!isset($this->paths[$namespace])) {
+      $this->paths[$namespace][] = $path;
+    } else {
+      array_unshift($this->paths[$namespace], $path);
+    }
+  }
+
+}

--- a/src/TwigLoader.php
+++ b/src/TwigLoader.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\twig_fractal\Component.
+ * Contains \Drupal\twig_fractal\TwigLoader.
  */
 
 namespace Drupal\twig_fractal;
@@ -13,26 +13,27 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 
 /**
- * Prepares paths to make fractal components overridable by a sub theme.
+ * Allows a subtheme to override Fractal components of its base theme.
  *
- * To make components overridable by a sub theme, the existing namespace paths
- * are getting prepended with adjusted sub theme paths.
+ * The filesystem path of a component that is overridden by the subtheme
+ * is prepended to the lookup paths of the component, so that it is found
+ * first.
  *
  * @see http://symfony.com/doc/current/templating/namespaced_paths.html#multiple-paths-per-namespace
  */
 class TwigLoader extends ComponentLibraryLoader {
 
   /**
-   * Prepends sub theme component paths to the existing base theme path namespaces.
-   *
    * {@inheritdoc}
    */
   public function __construct($paths = [], ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler) {
     parent::__construct($paths, $module_handler, $theme_handler);
+
     $default_theme = $theme_handler->getTheme($theme_handler->getDefault());
     if (!$default_theme->base_theme || !$base_theme = $theme_handler->getTheme($default_theme->base_theme)) {
       return;
     }
+
     foreach ($base_theme->info['component-libraries'] as $namespace => $component) {
       $paths = isset($component['paths']) ? $component['paths'] : [];
       foreach ($paths as $path) {
@@ -47,10 +48,12 @@ class TwigLoader extends ComponentLibraryLoader {
    */
   public function prependPath($path, $namespace = self::MAIN_NAMESPACE) {
     $this->cache = $this->errorCache = [];
+
     $path = rtrim($path, '/\\');
     if (!isset($this->paths[$namespace])) {
       $this->paths[$namespace][] = $path;
-    } else {
+    }
+    else {
       array_unshift($this->paths[$namespace], $path);
     }
   }

--- a/twig_fractal.services.yml
+++ b/twig_fractal.services.yml
@@ -7,4 +7,5 @@ services:
       class: Drupal\twig_fractal\TwigLoader
       arguments: ['@app.root', '@module_handler', '@theme_handler']
       tags:
+        # twig.loader.componentlibrary is registered with 200
         - { name: twig.loader, priority: 201 }

--- a/twig_fractal.services.yml
+++ b/twig_fractal.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\twig_fractal\TwigFractal
     tags:
       - { name: twig.extension }
+  twig.loader.twig_fractal:
+      class: Drupal\twig_fractal\TwigLoader
+      arguments: ['@app.root', '@module_handler', '@theme_handler']
+      tags:
+        - { name: twig.loader, priority: 201 }

--- a/twig_fractal.services.yml
+++ b/twig_fractal.services.yml
@@ -8,4 +8,4 @@ services:
       arguments: ['@app.root', '@module_handler', '@theme_handler']
       tags:
         # twig.loader.componentlibrary is registered with 200
-        - { name: twig.loader, priority: 201 }
+        - { name: twig.loader, priority: 210 }


### PR DESCRIPTION
**Issue:**
It's currently not possible to override components from a sub theme without duplicating/replacing the `component-libraries` key in the `theme.info.yml` file. To solve this, this PR extends the namespace by sub theme component paths to have multiple destinations for the templates like it's suggested from the [Twig documentation](http://symfony.com/doc/current/templating/namespaced_paths.html#multiple-paths-per-namespace).