### PR TITLE
Fixed PHP warning if base theme does not define 'component-libraries'.

### DIFF
--- a/src/TwigLoader.php
+++ b/src/TwigLoader.php
@@ -31,7 +31,7 @@ class TwigLoader extends ComponentLibraryLoader {
 
     $default_theme = $theme_handler->getTheme($theme_handler->getDefault());
     if ($base_theme = $default_theme->base_theme) {
-      $base_theme = $theme_handler->getTheme($default_theme->base_theme);
+      $base_theme = $theme_handler->getTheme($base_theme);
     }
     if (!$base_theme || !isset($base_theme->info['component-libraries'])) {
       return;

--- a/src/TwigLoader.php
+++ b/src/TwigLoader.php
@@ -30,7 +30,10 @@ class TwigLoader extends ComponentLibraryLoader {
     parent::__construct($paths, $module_handler, $theme_handler);
 
     $default_theme = $theme_handler->getTheme($theme_handler->getDefault());
-    if (!$default_theme->base_theme || !$base_theme = $theme_handler->getTheme($default_theme->base_theme)) {
+    if ($base_theme = $default_theme->base_theme) {
+      $base_theme = $theme_handler->getTheme($default_theme->base_theme);
+    }
+    if (!$base_theme || !isset($base_theme->info['component-libraries'])) {
       return;
     }
 


### PR DESCRIPTION
This PR fixes an undefined index warning if `info['component-libraries']` is not defined or set in the `theme.info.yml` file.