### PR TITLE
Fixed classes are not getting merged in compound attributes.

### DIFF
--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -123,7 +123,7 @@ class Render extends Twig_Node_Include {
           }
         }
       }
-      if ($name === 'attributes' && isset($defaults[$name]['class'])) {
+      if (FALSE !== strpos($name, 'attributes') && isset($defaults[$name]['class'])) {
         $variables[$name]->addClass($defaults[$name]['class']);
       }
     }


### PR DESCRIPTION
**Problem**
If passing a compound attribute key like `header_attributes` classes are not getting merged. Either the default classes from the component config or the given classes apply. Depending on the way of passing the variables. 