### PR TITLE
Fixed existing subtheme components are loaded from parent theme.

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -207,7 +207,7 @@ class Component {
    *   4. a list of variants, if any.
    */
   protected function extractParts(string $compound_name): array {
-    $library = Drupal::service('twig.loader.componentlibrary');
+    $library = Drupal::service('twig.loader.twig_fractal');
     $pathname = preg_replace('@--[^.]+@', '', $compound_name);
     $template_pathname = $library->exists($compound_name) ? $compound_name : $pathname;
 


### PR DESCRIPTION
**Issue**
- Existing subtheme components are loaded from the parent theme while the config is not

**Goal**
- If a component override exist in the sub theme, use this component, not the parent one.

**Proposed Solution**
- Use the custom Twig library loader of the module to prepend the sub theme paths. This will make Twig search on this locations first.