### PR TITLE
Fixed attributes are not rendered when no variables are passed.

### DIFF
--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -67,14 +67,15 @@ class Render extends Twig_Node_Include {
     $compiler->subcompile($this->getNode('expr'));
     $compiler->raw(')')->raw(";\n");
     $compiler->raw('$defaults = $component->getDefaultVariables();');
+    $compiler->raw('$passed_variables = [];');
     if (!$this->hasNode('variables')) {
       $compiler->raw('$variables = $defaults')->raw(";\n");
     }
     else {
       $compiler->raw('$passed_variables = ')->subcompile($this->getNode('variables'))->raw(";\n");
       $compiler->raw('$variables = array_merge($defaults, $passed_variables)')->raw(";\n");
-      $compiler->raw('$variables = \Drupal\twig_fractal\Node\Render::convertAttributes($variables, $defaults, $passed_variables)')->raw(";\n");
     }
+    $compiler->raw('$variables = \Drupal\twig_fractal\Node\Render::convertAttributes($variables, $defaults, $passed_variables)')->raw(";\n");
     $compiler
       ->write('$this->loadTemplate(')
       ->raw('$component->getTemplatePathname()')


### PR DESCRIPTION
### Problem
- The attributes are converted when variables are passed into the render tag only
  `{% render '@molecules/listing-header/listing-header.twig' with {} %}`
- This causes code overhead as templates need to be rendered with empty variables

### Goal
- Ensure the attributes are getting rendered as string and avoid code overhead and 