### PR TITLE
Added render tag array syntax support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ It can either be used as a Drupal module or as a standalone Twig extension.
     {% render '@atoms/button--primary.twig' with { label: 'Save' } %}
 
     {% render [
-      '@pages/section-foo.twig',
-      '@pages/section-bar.twig',
-      '@pages/section-baz.twig',
+      '@pages/section--trythis.twig',
+      '@pages/section--alternative.twig',
+      '@pages/section.twig',
     ] %}
+    
+    
     ```
 
     By design, the class name of a component or variant cannot be removed, it

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ It can either be used as a Drupal module or as a standalone Twig extension.
       '@pages/section--trythis.twig',
       '@pages/section--alternative.twig',
       '@pages/section.twig',
-    ] %}
-    
-    
+    ] %} 
     ```
 
     By design, the class name of a component or variant cannot be removed, it

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ It can either be used as a Drupal module or as a standalone Twig extension.
     {% render '@atoms/button.twig' with { name: 'submit' } %}
 
     {% render '@atoms/button--primary.twig' with { label: 'Save' } %}
+
+    {% render [
+      '@pages/section-foo.twig',
+      '@pages/section-bar.twig',
+      '@pages/section-baz.twig',
+    ] %}
     ```
 
     By design, the class name of a component or variant cannot be removed, it

--- a/src/Component.php
+++ b/src/Component.php
@@ -68,9 +68,11 @@ class Component {
    *   The default variables of the component.
    */
   public function getDefaultVariables(): array {
-    $component_definition = $this->loadDefinition($this->getPathname());
-
     $defaults = [];
+    if (!$definition_pathname = $this->getDefinitionFilePath($this->getPathname())) {
+      return $defaults;
+    }
+    $component_definition = $this->loadDefinition($definition_pathname);
     if (isset($component_definition['context'])) {
       $defaults = $this->mergeContext($defaults, $component_definition['context']);
     }
@@ -125,17 +127,16 @@ class Component {
   /**
    * Loads the Fractal YAML component definition file.
    *
-   * @param string $pathname
-   *   The pathname of the component's template file.
+   * @param string $definition_file_path
+   *   The file path of the component's definition file.
    *
    * @return array
-   *   The parsed component definition.
+   *   The loaded and parsed component definition.
    */
-  protected function loadDefinition(string $pathname) {
+  protected function loadDefinition(string $definition_file_path) {
     $component_data = [];
-    $definition_pathname = $this->getDefinitionFilePath($pathname);
-    if (file_exists($definition_pathname)) {
-      $component_data = Yaml::parse(file_get_contents($definition_pathname));
+    if (file_exists($definition_file_path)) {
+      $component_data = Yaml::parse(file_get_contents($definition_file_path));
     }
     return $component_data;
   }
@@ -154,7 +155,7 @@ class Component {
    * @return string
    *   The relative path for the component definition file.
    */
-  protected function getDefinitionFilePath(string $pathname): ?string {
+  public function getDefinitionFilePath($pathname): ?string {
     $loader = $this->env->getLoader();
     $pathinfo = pathinfo($pathname);
     $config_path = $pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.config.yml';

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -62,12 +62,19 @@ class Render extends Twig_Node_Include {
    */
   protected function addGetTemplate(Twig_Compiler $compiler) {
     $this->setEnvironment($compiler->getEnvironment());
-    $compiler->raw('$component = new \Drupal\twig_fractal\Component(');
-    $compiler->raw('\Drupal\twig_fractal\Node\Render::getEnvironment(),');
-    $compiler->subcompile($this->getNode('expr'));
-    $compiler->raw(')')->raw(";\n");
-    $compiler->raw('$defaults = $component->getDefaultVariables();');
-    $compiler->raw('$passed_variables = [];');
+    $compiler->raw('$handles = (array) ')->subcompile($this->getNode('expr'))->raw(';');
+    $compiler->raw('foreach($handles as $handle):');
+      $compiler->raw('$passed_variables = $defaults = [];');
+      $compiler->raw('$component = new \Drupal\twig_fractal\Component(');
+      $compiler->raw('\Drupal\twig_fractal\Node\Render::getEnvironment(),');
+      $compiler->raw('$handle');
+      $compiler->raw(')')->raw(";\n");
+      // Exit loop when component is found to not look further.
+      $compiler->raw('if ($component->getDefinitionFilePath($component->getPathname())):');
+        $compiler->raw('$defaults = $component->getDefaultVariables();');
+        $compiler->raw('break;');
+      $compiler->raw('endif;');
+    $compiler->raw('endforeach;');
     if (!$this->hasNode('variables')) {
       $compiler->raw('$variables = $defaults')->raw(";\n");
     }

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -66,8 +66,8 @@ class Render extends Twig_Node_Include {
     $compiler->raw('foreach($handles as $handle):');
       $compiler->raw('$passed_variables = $defaults = [];');
       $compiler->raw('$component = new \Drupal\twig_fractal\Component(');
-      $compiler->raw('\Drupal\twig_fractal\Node\Render::getEnvironment(),');
-      $compiler->raw('$handle');
+        $compiler->raw('\Drupal\twig_fractal\Node\Render::getEnvironment(),');
+        $compiler->raw('$handle');
       $compiler->raw(')')->raw(";\n");
       // Exit loop when component is found to not look further.
       $compiler->raw('if ($component->getDefinitionFilePath($component->getPathname())):');
@@ -85,11 +85,11 @@ class Render extends Twig_Node_Include {
     $compiler->raw('$variables = \Drupal\twig_fractal\Node\Render::convertAttributes($variables, $defaults, $passed_variables)')->raw(";\n");
     $compiler
       ->write('$this->loadTemplate(')
-      ->raw('$component->getTemplatePathname()')
-      ->raw(', ')
-      ->repr($this->getTemplateName())
-      ->raw(', ')
-      ->repr($this->getTemplateLine())
+        ->raw('$component->getTemplatePathname()')
+        ->raw(', ')
+        ->repr($this->getTemplateName())
+        ->raw(', ')
+        ->repr($this->getTemplateLine())
       ->raw(')')
     ;
   }

--- a/src/Node/Render.php
+++ b/src/Node/Render.php
@@ -63,12 +63,14 @@ class Render extends Twig_Node_Include {
   protected function addGetTemplate(Twig_Compiler $compiler) {
     $this->setEnvironment($compiler->getEnvironment());
     $compiler->raw('$handles = (array) ')->subcompile($this->getNode('expr'))->raw(';');
+    $compiler->raw('$templates = [];');
     $compiler->raw('foreach($handles as $handle):');
       $compiler->raw('$passed_variables = $defaults = [];');
       $compiler->raw('$component = new \Drupal\twig_fractal\Component(');
         $compiler->raw('\Drupal\twig_fractal\Node\Render::getEnvironment(),');
         $compiler->raw('$handle');
       $compiler->raw(')')->raw(";\n");
+      $compiler->raw('$templates[] = $component->getTemplatePathname();');
       // Exit loop when component is found to not look further.
       $compiler->raw('if ($component->getDefinitionFilePath($component->getPathname())):');
         $compiler->raw('$defaults = $component->getDefaultVariables();');
@@ -85,7 +87,7 @@ class Render extends Twig_Node_Include {
     $compiler->raw('$variables = \Drupal\twig_fractal\Node\Render::convertAttributes($variables, $defaults, $passed_variables)')->raw(";\n");
     $compiler
       ->write('$this->loadTemplate(')
-        ->raw('$component->getTemplatePathname()')
+        ->raw('$templates')
         ->raw(', ')
         ->repr($this->getTemplateName())
         ->raw(', ')


### PR DESCRIPTION
### Description
- This PR adds support for using the array syntax in the render tag to look for multiple template files

### Example
```twig
{% render [
  '@pages/section-foo.twig',
  '@pages/section-bar.twig',
  '@pages/section-baz.twig',
] %}
```