### PR TITLE
Added functionality to get variants from the component configuration file.

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -147,7 +147,7 @@ class Component {
    * @return array
    *   The loaded component variants.
    */
-  public function getComponentVariants(): array {
+  public function getConfigVariants(): array {
     $definition_pathname = $this->getDefinitionFilePath($this->getPathname());
     $component_definition = $this->loadDefinition($definition_pathname);
     return array_column($component_definition['variants'], 'name', 'name');

--- a/src/Component.php
+++ b/src/Component.php
@@ -142,6 +142,18 @@ class Component {
   }
 
   /**
+   * Returns the array of variants from the component configuration file.
+   *
+   * @return array
+   *   The loaded component variants.
+   */
+  public function getComponentVariants(): array {
+    $definition_pathname = $this->getDefinitionFilePath($this->getPathname());
+    $component_definition = $this->loadDefinition($definition_pathname);
+    return array_column($component_definition['variants'], 'name', 'name');
+  }
+
+  /**
    * Returns the relative file path of the Fractal YAML configuration file for a given component name.
    *
    * Like Fractal, this implementation does not support separate configuration


### PR DESCRIPTION
In Wordpress, sometimes an array of the component variants need to be loaded for the component. I have moved this functionality into the twig Drupal implementation as it may be usefull elsewhere. 

One of the issues is that Component has a getter method `getVariants` so I went with the name `getComponentVariants()`. I couldn't think of a better name for thie method. 

Here's a code example:
```
$component = new \Drupal\twig_fractal\Component($twig, '@atoms/button/button.twig');
$buttonVariants = $component->getComponentVariants();
```