### PR TITLE
Added netzstrategen/drupal-attributes as a dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,14 @@
     "psr-4": {
       "Drupal\\twig_fractal\\": "src/"
     }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/netzstrategen/drupal-attributes"
+    }
+  ],
+  "require": {
+    "netzstrategen/drupal-attributes": "dev-master"
   }
 }


### PR DESCRIPTION
Not sure if I have setup this dependancy correctly. 

I tried adding this into the theme to test the dependency but it wasn't working.
```
"require": {
    "drupal/twig_fractal": "dev-feature/drupal-attributes-dependancy-callum"
}
``` 

I have not added any information, readme etc to [the other repository](https://github.com/netzstrategen/drupal-attributes) yet. 

