### PR TITLE
Added Drupal `create_attribute` Twig helper function.

### DIFF
--- a/src/TwigFractal.php
+++ b/src/TwigFractal.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\twig_fractal;
 
+use Drupal\Core\Template\Attribute;
 use Drupal\twig_fractal\TokenParser\Render;
 use Drupal\twig_fractal\NodeVisitors\Attributes;
 use Twig_Extension;
@@ -38,6 +39,12 @@ class TwigFractal extends Twig_Extension {
     ];
   }
 
+  public function getFunctions() {
+    return [
+      new \Twig_SimpleFunction('create_attribute', [$this, 'createAttribute']),
+    ];
+  }
+
   /**
    * Returns the extension name.
    *
@@ -46,6 +53,20 @@ class TwigFractal extends Twig_Extension {
    */
   public function getName(): string {
     return 'twig_fractal';
+  }
+
+  /**
+   * Creates an Attribute object.
+   *
+   * @param array $attributes
+   *   (optional) An associative array of key-value pairs to be converted to
+   *   HTML attributes.
+   *
+   * @return \Drupal\Core\Template\Attribute
+   *   An attributes object that has the given attributes.
+   */
+  public function createAttribute(array $attributes = []) {
+    return new Attribute($attributes);
   }
 
 }


### PR DESCRIPTION
This PR adds the `create_attribute` Twig helper function from Drupal https://github.com/drupal/drupal/blob/8.6.x/core/lib/Drupal/Core/Template/TwigExtension.php#L619-L631

Currently, the components share one Attribute object which requires workarounds to render looped items as expected. If a class is added to the Attribute object, its added the initial Attribute and thus all subsequent components will have the same attributes, for example nav items.


Each nav item should have it's own Attribute object instead where the defaults are getting merged to e.g. `attributes: create_attribute().merge(link_attributes).merge(link.attributes ? link.attributes : null).setAttribute('href', link.href),`

The original `link_attributes` object stays untouched.

I'm going to implement a similar functionality in https://github.com/netzstrategen/fractal-twig as well to have it working in fractal, too.